### PR TITLE
Fix/GitHub actions node version

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Configure Git User
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Deploy to GitHub Pages
         run: npm run deploy
         env:

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Configure Git User
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "Rafael P Lourenço"
+          git config --global user.email "rafaelpototskylourenco10@gmail.com"
 
       - name: Deploy to GitHub Pages
         run: npm run deploy


### PR DESCRIPTION
"Author identity unknown" error. This was because the Git user name and email were not configured in the GitHub Actions runner environment.

To solve this, I added a step to the `gh-pages-deploy.yml` workflow to configure a generic Git user identity (`github-actions[bot]`) before the deployment command is executed. This will allow the `angular-cli-ghpages` tool to create the deployment commit successfully.